### PR TITLE
fix: add jsconfig.json to support Peek/Go to Definition

### DIFF
--- a/jsconfig.json
+++ b/jsconfig.json
@@ -1,0 +1,12 @@
+{
+  "compilerOptions": {
+    "baseUrl": ".",
+    "paths": {
+      "react/*":["packages/react/*"],
+      "reactDOM/*":["packages/reactDOM/*"],
+      "reactReconciler/*": ["packages/react-reconciler/*"],
+      "scheduler/*": ["packages/scheduler/*"],
+      "shared/*": ["packages/shared/*"],
+    }
+  }
+}


### PR DESCRIPTION
增加 jsconfig.json 配置方便阅读代码时在各个模块之间跳转。
参考：https://github.com/microsoft/vscode/issues/16320